### PR TITLE
Fix 0 values in smarty transformation

### DIFF
--- a/Components/SwagImportExport/Transformers/ValuesTransformer.php
+++ b/Components/SwagImportExport/Transformers/ValuesTransformer.php
@@ -94,7 +94,7 @@ class ValuesTransformer implements DataTransformerAdapter
                     foreach ($conversions as $variableName => $conversion) {
                         if (isset($record[$variableName]) && !empty($conversion)) {
                             $evalData = $this->evaluator->evaluate($conversion, $record);
-                            if ($evalData) {
+                            if ($evalData || $evaldata == "0") {
                                 $record[$variableName] = $evalData;
                             }
                         }

--- a/Components/SwagImportExport/Transformers/ValuesTransformer.php
+++ b/Components/SwagImportExport/Transformers/ValuesTransformer.php
@@ -94,7 +94,7 @@ class ValuesTransformer implements DataTransformerAdapter
                     foreach ($conversions as $variableName => $conversion) {
                         if (isset($record[$variableName]) && !empty($conversion)) {
                             $evalData = $this->evaluator->evaluate($conversion, $record);
-                            if ($evalData || $evaldata == "0") {
+                            if ($evalData || $evaldata === "0") {
                                 $record[$variableName] = $evalData;
                             }
                         }


### PR DESCRIPTION
Currently it is not possible to set a value to "0" (zero) with the smarty conversion, because if($evalData) is false in case $evalData is "0". 

Please see: 
https://forum.shopware.com/discussion/comment/215298/#Comment_215298
https://3v4l.org/iX613